### PR TITLE
Fix future deprecations

### DIFF
--- a/cmcrameri/cm.py
+++ b/cmcrameri/cm.py
@@ -5,9 +5,11 @@ https://www.fabiocrameri.ch/colourmaps/
 Created by Callum Rollo
 2020-05-06
 """
+
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
-
+from packaging import version
 
 _cmap_names_sequential = (
     "batlow", "batlowW", "batlowK",
@@ -58,7 +60,11 @@ def _load_cmaps():
 
     def register(cmap):
         # Register in Matplotlib
-        plt.cm.register_cmap(name=f"{cmap_reg_prefix}{cmap.name}", cmap=cmap)
+        if version.parse(matplotlib.__version__) < version.parse("3.5"):
+            plt.cm.register_cmap(name=f"{cmap_reg_prefix}{cmap.name}", cmap=cmap)
+        else:
+            matplotlib.colormaps.register(cmap=cmap, name=f"{cmap_reg_prefix}{cmap.name}")
+
         # Add to dict
         cmaps[cmap.name] = cmap
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 matplotlib
+packaging

--- a/tests/test_cmcrameri.py
+++ b/tests/test_cmcrameri.py
@@ -4,6 +4,7 @@ Test that the program a) finds the text files and b) creates colormaps
 import sys
 from pathlib import Path
 
+import numpy as np
 from matplotlib.colors import Colormap
 from matplotlib.pyplot import get_cmap
 
@@ -38,8 +39,8 @@ def test_get_cmap():
             # if cmap hasn't been correctly registered as
             # cmc.name, it will raise a ValueError
             alt_cmap = get_cmap('cmc.' + name)
-            # alt_cmap returned by get_cmap should be the same instance as cmap
-            assert alt_cmap is cmap
+            # alt_cmap returned by get_cmap should be the same as cmap
+            assert (np.array(cmap.colors) == np.array(alt_cmap.colors)).all()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**What does your PR do?**

Fix a future deprecation in matplotlib when registering the cmaps.

**Testing**

There is no new functionality but a test was broken in matplotlib >3.5 b/c one could not compare the cmap objects directly, some of those are the same but a new instance with a different object id. I modified the tests to compare the values instead.